### PR TITLE
Update Array.seqentialFill Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ It will be available as the global `ML` variable. The package is in UMD format.
 - [`ML.Array.mode`](https://github.com/mljs/array/tree/master/packages/array-mode)
 - [`ML.Array.normed`](https://github.com/mljs/array/tree/master/packages/array-normed)
 - [`ML.Array.rescale`](https://github.com/mljs/array/tree/master/packages/array-rescale)
-- [`ML.Array.sequentialFill`](https://github.com/mljs/array/tree/master/packages/'ml-array-sequential-fill)
+- [`ML.Array.sequentialFill`](https://github.com/mljs/array/tree/master/packages/array-sequential-fill)
 - [`ML.Array.standardDeviation`](https://github.com/mljs/array/tree/master/packages/array-standard-deviation)
 - [`ML.Array.variance`](https://github.com/mljs/array/tree/master/packages/array-variance)
 


### PR DESCRIPTION
The link to sequentialFill was pointing to a 404. I fixed the destination.